### PR TITLE
Disable autoplay for trailer

### DIFF
--- a/cinelog/home/templates/movie_detail.html
+++ b/cinelog/home/templates/movie_detail.html
@@ -85,9 +85,8 @@
     <div class="trailer-container">
         <iframe
             id="trailer-iframe"
-            src="https://www.youtube.com/embed/{{ trailer.key }}?autoplay=1"  
+            src="https://www.youtube.com/embed/{{ trailer.key }}?autoplay=0"  
             allowfullscreen 
-            allow="autoplay"
             referrerpolicy="strict-origin-when-cross-origin">
         </iframe>
         <button onclick="closeTrailer()" class="trailer-close">✕</button>


### PR DESCRIPTION
Fix the autoplay so that trailers play in the background after a user clicks on a movie.