### PR TITLE
Upgrade Django from 4.2.11 to 4.2.30 

### DIFF
--- a/cinelog/requirements.txt
+++ b/cinelog/requirements.txt
@@ -20,7 +20,7 @@ deprecation==2.1.0
 dill==0.4.1
 distro==1.9.0
 dj-database-url==3.1.2
-Django==4.2.11
+Django==4.2.30
 djangorestframework==3.16.1
 fsspec==2026.3.0
 gunicorn==25.1.0


### PR DESCRIPTION
Needed to address CVE-2024-38875 and 18 other security patches.