### PR TITLE
Removed .devedu.io from ALLOWED_HOSTS in settings.py

### DIFF
--- a/cinelog/cinelog/settings.py
+++ b/cinelog/cinelog/settings.py
@@ -58,7 +58,6 @@ if not SECRET_KEY and not os.environ.get("CI"):
 DEBUG = False
 
 ALLOWED_HOSTS = [
-    ".devedu.io",
     "localhost",
     "127.0.0.1",
     "cinelog-service-production.up.railway.app",


### PR DESCRIPTION
Removed .devedu.io wildcard from ALLOWED_HOSTS to resolve a medium-severity security concern where any devedu.io (https://devedu.io/) subdomain could potentially serve the application. This change does not affect production since the wildcard was only active when DEVELOPMENT=true, and local development continues to work via localhost and 127.0.0.1.